### PR TITLE
Support for node 4.x

### DIFF
--- a/devices/dummy.coffee
+++ b/devices/dummy.coffee
@@ -3,13 +3,13 @@ module.exports = (env) ->
   _ = require 'lodash'
   Color = require 'color'
   BaseLedLight = require('./base')(env)
-  
+
   class DummyLedLight extends BaseLedLight
-  
+
     constructor: (@config, lastState) ->
       @device = @
-      @name = config.name
-      @id = config.id
+      @name = @config.name
+      @id = @config.id
       @_dimlevel = lastState?.dimlevel?.value or 0
 
       initState = _.clone lastState
@@ -21,29 +21,28 @@ module.exports = (env) ->
     _updateState: (attr) ->
       state = _.assign @getState(), attr
       super null, state
-      
+
     turnOn: ->
       @_updateState power: true
       Promise.resolve()
-      
+
     turnOff: ->
       @_updateState power: false
       Promise.resolve()
-      
+
     setColor: (newColor) ->
       color = Color(newColor).rgb()
       @_updateState
         mode: @COLOR_MODE
         color: color
       Promise.resolve()
-      
+
     setWhite: ->
       @_updateState mode: @WHITE_MODE
       Promise.resolve()
-      
+
     setBrightness: (newBrightness) ->
       @_updateState brightness: newBrightness
       Promise.resolve()
-      
+
   return DummyLedLight
-      

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "node-milight-promise": ">=0.0.3",
     "node-milight-rf24": ">=0.1.1",
     "lodash": "^3.10.1",
-    "blinkstick": "1.1.1",
+    "blinkstick": "1.1.3",
     "hyperion-client": "1.0.0",
     "event-to-promise": "0.6.0"
   },


### PR DESCRIPTION
While testing the v0.9.x branch of pimatic i've seen errors when starting pimatic-led-light. 
I had to update the blinkstick dependency to 1.1.3, otherwise some transitive dependencies couldn't be compiled. When starting pimatic i found another error in the DummyLedLight device (see commit)
