### PR TITLE
Added priority config for Hyperion

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ Get the sketch from here https://github.com/henryk/openmili and change the CE an
       "id": "some_id",
       "name": "some_name",
       "class": "Hyperion",
-      "addr": "xxx.xxx.xxx.xxx"
+      "addr": "xxx.xxx.xxx.xxx",
+      "priority": 100 // Only if you want to change the used priority, default is 100.
     }
 ```
 
@@ -112,4 +113,3 @@ Get the sketch from here https://github.com/henryk/openmili and change the CE an
   - by name (in rules e.g. red)
   - by hex (in rules e.g. #00FF00)
   - by temperature variable from weather plugin (in rules e.g. $weather.temperature)
-

--- a/device-config-schema.coffee
+++ b/device-config-schema.coffee
@@ -84,5 +84,9 @@ module.exports = {
         description: "Port of hyperion device"
         type: "string",
         default: "19444"
+      priority:
+        description: "Priority used for hyperion calls"
+        type: "number"
+        default: 100
   }
 }

--- a/devices/hyperion.coffee
+++ b/devices/hyperion.coffee
@@ -85,7 +85,7 @@ module.exports = (env) ->
       if @_connected
         return Promise.resolve(@hyperion)
       else
-        @hyperion = new Hyperion(@config.addr, @config.port)
+        @hyperion = new Hyperion(@config.addr, @config.port, @config.priority)
         @hyperion.on 'error', (error) =>
           env.logger.error("Error connecting to hyperion.")
           if (error?)

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "node-milight-rf24": ">=0.1.1",
     "lodash": "^3.10.1",
     "blinkstick": "1.1.1",
-    "hyperion-client": "1.0.0",
+    "hyperion-client": "1.0.3",
     "event-to-promise": "0.6.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
hyperion-client 1.0.3 added the possibility to set the used priority for calls against the hyperion device. This PR forwards this feature to the device config in pimatic.
